### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "highlightjs-chapel",
+  "version": "0.1.0",
+  "description": "highlight.js support for Chapel",
+  "main": "src/languages/chapel.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chapel-lang/highlightjs-chapel.git"
+  },
+  "keywords": [
+    "chapel",
+    "highlight.js",
+    "highlightjs",
+    "syntax"
+  ],
+  "author": "Chapel Team, HPE",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/chapel-lang/highlightjs-chapel/issues"
+  },
+  "homepage": "https://github.com/chapel-lang/highlightjs-chapel#readme"
+}


### PR DESCRIPTION
This pull request adds `package.json` to the repository, which is needed to register the plugin in NPM (which would make installing and using this in external websites much easier). See discussion in #8
